### PR TITLE
easyeffects: 6.1.3 -> 6.2.3

### DIFF
--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -4,11 +4,13 @@
 , fetchFromGitHub
 , calf
 , fftwFloat
+, fmt
 , glib
 , glibmm
 , gtk4
 , gtkmm4
 , itstool
+, libadwaita
 , libbs2b
 , libebur128
 , libsamplerate
@@ -26,6 +28,7 @@
 , rnnoise
 , rubberband
 , speexdsp
+, tbb
 , wrapGAppsHook4
 , zam-plugins
 , zita-convolver
@@ -33,13 +36,13 @@
 
 stdenv.mkDerivation rec {
   pname = "easyeffects";
-  version = "6.1.3";
+  version = "6.2.3";
 
   src = fetchFromGitHub {
     owner = "wwmm";
     repo = "easyeffects";
     rev = "v${version}";
-    sha256 = "sha256-1UfeqPJxY4YT98UdqTZtG+QUBOZlKfK+7WbszhO22A0=";
+    sha256 = "sha256-A1UanrAbmZFGCmDNIr1h+v5RVMsIl4qgM/veBirudQM=";
   };
 
   nativeBuildInputs = [
@@ -49,15 +52,18 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
+    tbb
     wrapGAppsHook4
   ];
 
   buildInputs = [
     fftwFloat
+    fmt
     glib
     glibmm
     gtk4
     gtkmm4
+    libadwaita
     libbs2b
     libebur128
     libsamplerate


### PR DESCRIPTION
1. Updated to the newest version.
2. Added some build and runtime dependencies according to build errors.

###### Motivation for this change
#158476

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
